### PR TITLE
[Bugfix] Dependencies Installation issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='trustauthx',
-    version='0.5.1',
+    version='0.5.2',
     description='Official connector SDK for TrustAuthx',
     long_description=long_description,
     long_description_content_type='text/markdown',  # This is important!

--- a/trustauthx/cli.py
+++ b/trustauthx/cli.py
@@ -62,11 +62,11 @@ def main():
         print("\nInstalling dependencies...")
         def install(packages):
             if packages == "pip install fastapi['all']":
-                subprocess.call("pip install fastapi['all']")
+                subprocess.call("pip install fastapi['all']", shell=True)
                 return
             if isinstance(packages, list):
-                for package in packages:subprocess.call(package)
-            else:subprocess.call(packages)
+                for package in packages:subprocess.call(package, shell=True)
+            else:subprocess.call(packages, shell=True)
         install(list_depends)
         print("\nDependencies installed.")
         a = sdk.Create_App(path=os.getcwd())


### PR DESCRIPTION
The dependencies are not getting installed because it is unable to detect the pip properly. To fix that issue I added shell=True which executes the command directly in the shell.

Error Message:
![image](https://github.com/One-Click-Auth/TrustAuthx-Py-SDK/assets/34382211/2592f694-7489-44bd-abfd-e6abd4ed2f0f)
